### PR TITLE
Add tests, raytracing, and fixes

### DIFF
--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -590,8 +590,8 @@ namespace pc {
                 vk = apf::getLinearCentroid(m, verts[j + 1]),
                 edge_v = vk - vj;
               apf::Matrix<2,2> mat;
-              mat[0][0] = ray[0]; mat[0][1] = edge_v[0];
-              mat[1][0] = ray[1]; mat[1][1] = edge_v[1];
+              mat[0][0] = ray[0]; mat[0][1] = -edge_v[0];
+              mat[1][0] = ray[1]; mat[1][1] = -edge_v[1];
               apf::Vector3 soln = vj - src;
               apf::Vector<2> soln_2(&soln[0]);
               constexpr double det_tol = 1.0e-14;
@@ -613,7 +613,7 @@ namespace pc {
                 apf::Matrix<2,2> mat_inv = apf::invert(mat);
                 apf::Vector<2> x = mat_inv * soln_2;
                 apf::Vector3 e_lc = apf::getLinearCentroid(m, e);
-                exit_intersection = edge_v * x[1];
+                exit_intersection = edge_v * x[1] + vj;
                 if (x[0] < 0 || (edge_v*x[1] - e_lc) * ray < 0) {
                   // Entry edge or edge in same plane as entry edge.
                   continue;

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -713,9 +713,9 @@ namespace pc {
         #endif
         apf::Downward points;
         m->getDownward(exit_edge, 0, points);
-        apf::Vector v1 = apf::getLinearCentroid(m, points[0]),
+        apf::Vector3 v1 = apf::getLinearCentroid(m, points[0]),
           v2 = apf::getLinearCentroid(m, points[1]);
-        apf::Vector edge_plane_normal = apf::cross(v1 - src, v2 - src).normalize();
+        apf::Vector3 edge_plane_normal = apf::cross(v1 - src, v2 - src).normalize();
         apf::Adjacent rgns;
         m->getAdjacent(exit_edge, 3, rgns);
         PCU_DEBUG_ASSERT(rgns.size() > 1); // At least us and somebody else.

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -475,6 +475,7 @@ namespace pc {
    * @param m APF Mesh.
    * @input-field "Shock_Param"
    * @output-field "Shock_Param"
+   * @TODO Think about the name.
    */
   void defragmentShocksSerial(const ph::Input& in, apf::Mesh2* m) {
     apf::Field* Shock_Param = m->findField("Shock_Param");
@@ -484,7 +485,7 @@ namespace pc {
       if (apf::getScalar(Shock_Param, e, 0) == ShockParam::SHOCK) {
         double dist_max = getMaxRadius(m, e); // Max linear search distance.
         serialBFS(m, 3, e, [dist_max](const BFSarg& arg) -> BFSresult {
-          if (arg.distance > 1) return BFSresult::BREAK;
+          if (arg.distance > 2) return BFSresult::BREAK;
           apf::Vector3 e_lc = apf::getLinearCentroid(arg.m, arg.e);
           apf::Vector3 c_lc = apf::getLinearCentroid(arg.m, arg.c);
           apf::Vector3 dist =  e_lc - c_lc;
@@ -522,33 +523,37 @@ namespace pc {
 		// Initialize BFS field.
 		apf::MeshIterator* it = m->begin(3);
 		for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
-			apf::Vector3 bfs_trip(-1, -1, std::numeric_limits<double>::infinity());
+			apf::Vector3 bfs_trip(-1, -1, -1);
 			apf::setVector(pc_cs_bfs, e, 0, bfs_trip);
 		}
 		m->end(it);
 
 		Shocks shocks;
+		int current_component = -1;
 
 		serialBFS(
 				m, 3,
 				[Shock_Param, pc_cs_bfs](const BFSarg& arg) -> BFSresult {
 					apf::Vector3 v;
 					apf::getVector(pc_cs_bfs, arg.e, 0, v);
-					return apf::getScalar(Shock_Param, arg.e, 0) == ShockParam::SHOCK &&
+					return apf::getScalar(Shock_Param, arg.e, 0) != ShockParam::NONE &&
 								 v.y() < 0 ? BFSresult::ACT : BFSresult::CONTINUE;
 				},
-				[pc_cs_bfs, &shocks](const BFSarg& arg) {
+				[pc_cs_bfs, &shocks, &current_component](const BFSarg& arg) {
+					// Check if this is a new shock component.
+					if (arg.component != current_component) {
+						shocks.emplace_back();
+						current_component = arg.component;
+					}
+
 					apf::Vector3 v;
 					apf::getVector(pc_cs_bfs, arg.e, 0, v);
 					v.x() = PCU_Comm_Self();
-					v.y() = arg.component;
+					v.y() = shocks.size();
 					v.z() = arg.distance;
 					apf::setVector(pc_cs_bfs, arg.e, 0, v);
 
-					if (arg.component >= shocks.size()) {
-						shocks.push_back(std::vector<apf::MeshEntity*>());
-						shocks[arg.component].push_back(arg.e);
-					}
+					shocks.back().push_back(arg.e);
 				});
 
 		// FIXME: Process part boundary (repeated triplet max.)

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -758,7 +758,7 @@ namespace pc {
           return;
         } else if (visited.find(opposite_rgn) == visited.end()) {
           #ifndef NDEBUG
-          std::cout << "Choosing " << opposite_rgn << " as next element. ";
+          std::cout << "Choosing " << opposite_rgn << " as next element." << std::endl;
           #endif
           e = opposite_rgn;
           entry_ent = exit_edge;

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -596,22 +596,31 @@ namespace pc {
               // ind == 0 implies edge and ray share a plane; change coordinate
               // system so z is constant, then solve with 2x2 matrix.
               apf::Matrix3x3 coord_change;
-              coord_change[0] = edge_v;
-              coord_change[1] = ray - apf::project(edge_v, ray);
+              coord_change[0] = edge_v.normalize();
+              coord_change[1] = ray - apf::project(coord_change[0], ray);
               coord_change[2] = apf::cross(coord_change[0], coord_change[1]);
               coord_change = apf::transpose(coord_change);
               constexpr double det_tol = 1.0e-14;
-              if (std::abs(apf::getDeterminant(coord_change)) < det_tol) {
+              double det = apf::getDeterminant(coord_change);
+              if (std::abs(det) < det_tol) {
                 // Ray and edge are aligned.
                 constexpr double dot_tol = 1.0e-14;
                 if (std::abs((vj - src).normalize() * ray - 1.0) >= dot_tol) {
                   // Ray and edge are aligned but translated.
                   continue;
                 } else if (ray * edge_v > 0) {
+                  if (entry_ent == verts[j + 1]) {
+                    // Found the entry vert.
+                    continue;
+                  }
                   exit_vert = verts[j + 1];
                   exit_intersection = vk;
                 } else {
                   PCU_DEBUG_ASSERT(ray * edge_v < 0);
+                  if (entry_ent == verts[j]) {
+                    // Found the entry vert.
+                    continue;
+                  }
                   exit_vert = verts[j];
                   exit_intersection = vj;
                 }
@@ -624,7 +633,7 @@ namespace pc {
               mat[1][0] = ray_til[1]; mat[1][1] = -e_til[1];
               apf::Vector3 soln = trans_mat * (vj - src);
               apf::Vector<2> soln_2(&soln[0]);
-              double det = apf::getDeterminant(mat);
+              det = apf::getDeterminant(mat);
               if (std::abs(det) < 1.0e-14) {
                 std::cout << "ERROR: Unexpected 0 determinant." << std::endl; // um
                 continue;
@@ -641,6 +650,8 @@ namespace pc {
               if (std::abs(x[1]) < x_tol) {
                 exit_vert = verts[j];
               } else if (std::abs(x[1] - 1) < x_tol) {
+                // Cannot be entry vert because intersection is oriented with
+                // ray.
                 exit_vert = verts[j + 1];
               } else if (0 <= x[1] && x[1] <= 1) {
                 exit_edge = edge;

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -472,8 +472,22 @@ namespace pc {
     return ind < 0 ? -1 : 1;
   }
 
+  // FIXME: Hard vertex maps.
   constexpr int tet_face_verts_ccw[4][3] = {
     {0, 2, 1}, {0, 1, 3}, {1, 2, 3}, {0, 3, 2}
+  };
+
+  constexpr int hex_face_verts_ccw[6][4] = {
+    {0, 3, 2, 1}, {0, 1, 5, 4}, {1, 2, 6, 5},
+    {2, 3, 7, 6}, {0, 4, 7, 3}, {4, 5, 6, 7}
+  };
+
+	constexpr int prism_face_verts_ccw[5][4] = {
+    {0, 2, 1, -1}, {0, 1, 4, 3}, {1, 2, 5, 4}, {0, 3, 5, 2}, {3, 4, 5, -1}
+  };
+
+	constexpr int pyramid_face_verts_ccw[5][4] = {
+    {0, 3, 2, 1}, {0, 1, 4, -1}, {1, 2, 4, -1}, {2, 3, 4, -1}, {0, 4, 3, -1}
   };
 
   int getFaceVertsCCW(apf::Mesh* m, apf::MeshEntity* e, int face,
@@ -486,6 +500,21 @@ namespace pc {
         verts[i] = verts_tmp[tet_face_verts_ccw[face][i]];
       }
       return 3;
+    case apf::Mesh::HEX:
+      for (int i = 0; i < 4; ++i) {
+        verts[i] = verts_tmp[hex_face_verts_ccw[face][i]];
+      }
+      return 4;
+    case apf::Mesh::PRISM:
+      for (int i = 0; i < 4; ++i) {
+        verts[i] = verts_tmp[prism_face_verts_ccw[face][i]];
+      }
+      return prism_face_verts_ccw[face][3] == -1 ? 3 : 4;
+    case apf::Mesh::PYRAMID:
+      for (int i = 0; i < 4; ++i) {
+        verts[i] = verts_tmp[pyramid_face_verts_ccw[face][i]];
+      }
+      return pyramid_face_verts_ccw[face][3] == -1 ? 3 : 4;
     default:
       std::cerr << "ERROR: mesh type not implemented.\n" << std::endl;
       return 0;

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -729,11 +729,13 @@ namespace pc {
    */
   void denoiseShocksSerial(const ph::Input& in, apf::Mesh2* m, Shocks& shocks, int minsize = 10) {
     apf::Field* Shock_Param = m->findField("Shock_Param");
+    apf::Field* pc_cs_bfs = m->findField("pc_cs_bfs");
 
     for (auto it = shocks.begin(); it != shocks.end();) {
       if (it->size() < minsize) {
         for (auto it2 = it->begin(); it2 != it->end(); ++it2) {
           apf::setScalar(Shock_Param, *it2, 0, ShockParam::NONE);
+          apf::setVector(pc_cs_bfs, *it2, 0, apf::Vector3(-1, -1, -1));
         }
         it = shocks.erase(it);
       } else {

--- a/pcAdapter2.cc
+++ b/pcAdapter2.cc
@@ -597,7 +597,11 @@ namespace pc {
               constexpr double det_tol = 1.0e-14;
               if (std::abs(apf::getDeterminant(mat)) < det_tol) {
                 // Singular matrix; non-invertible. Ray and edge are aligned.
-                if (ray * edge_v > 0) {
+                constexpr double dot_tol = 1.0e-14;
+                if (std::abs((vj - src).normalize() * ray - 1.0) >= dot_tol) {
+                  // Ray and edge are aligned but translated.
+                  continue;
+                } else if (ray * edge_v > 0) {
                   exit_vert = verts[j + 1];
                   exit_intersection = vk;
                 } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,23 +1,25 @@
 include(testing.cmake)
 
-add_executable(test_defragmentation test_defragmentation.cc
+add_executable(test_defragmentation EXCLUDE_FROM_ALL test_defragmentation.cc
   "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
 )
 
 target_include_directories(test_defragmentation PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_defragmentation PRIVATE SCOREC::core)
 
-add_executable(test_raytracing test_raytracing.cc "${CMAKE_SOURCE_DIR}/pcAdapter2.cc")
+add_executable(test_raytracing EXCLUDE_FROM_ALL test_raytracing.cc
+  "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
+)
 target_link_libraries(test_raytracing PRIVATE SCOREC::core)
 
-add_executable(test_labeling test_labeling.cc
+add_executable(test_labeling EXCLUDE_FROM_ALL test_labeling.cc
   "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
 )
 
 target_include_directories(test_labeling PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_labeling PRIVATE SCOREC::core)
 
-add_executable(test_prisms test_prisms.cc
+add_executable(test_prisms EXCLUDE_FROM_ALL test_prisms.cc
   "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,11 @@
 include(testing.cmake)
 
-add_executable(test_defragmentation EXCLUDE_FROM_ALL test_defragmentation.cc
+add_executable(test_defragmentation test_defragmentation.cc
   "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
 )
 
 target_include_directories(test_defragmentation PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_defragmentation PRIVATE SCOREC::core)
+
+add_executable(test_raytracing test_raytracing.cc "${CMAKE_SOURCE_DIR}/pcAdapter2.cc")
+target_link_libraries(test_raytracing PRIVATE SCOREC::core)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,3 +16,10 @@ add_executable(test_labeling test_labeling.cc
 
 target_include_directories(test_labeling PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_labeling PRIVATE SCOREC::core)
+
+add_executable(test_prisms test_prisms.cc
+  "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
+)
+
+target_include_directories(test_prisms PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_prisms PRIVATE SCOREC::core)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,8 @@
 include(testing.cmake)
+
+add_executable(test_labeling test_labeling.cc
+  "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
+)
+
+target_include_directories(test_labeling PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(test_labeling PRIVATE SCOREC::core)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,8 @@
 include(testing.cmake)
+
+add_executable(test_defragmentation EXCLUDE_FROM_ALL test_defragmentation.cc
+  "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
+)
+
+target_include_directories(test_defragmentation PRIVATE "${CMAKE_SOUCE_DIR}")
+target_link_libraries(test_defragmentation PRIVATE SCOREC::core)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,5 +4,5 @@ add_executable(test_defragmentation EXCLUDE_FROM_ALL test_defragmentation.cc
   "${CMAKE_SOURCE_DIR}/pcAdapter2.cc"
 )
 
-target_include_directories(test_defragmentation PRIVATE "${CMAKE_SOUCE_DIR}")
+target_include_directories(test_defragmentation PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(test_defragmentation PRIVATE SCOREC::core)

--- a/test/ShockFunc.h
+++ b/test/ShockFunc.h
@@ -26,7 +26,7 @@ namespace pc {
     };
 
     /**
-     * @brief A 3D Planar shock function |Ax+By+Cz+D|<=tol.
+     * @brief A 3D Planar shock function |Ax+By+Cz-D|<=tol.
      * 
      */
     class PlanarShockFunc : public ShockFunc {
@@ -37,10 +37,27 @@ namespace pc {
     private:
       virtual bool eval(apf::Mesh* m, apf::MeshEntity* e) {
         apf::Vector3 lc = apf::getLinearCentroid(m, e);
-        return std::abs(a * lc.x() + b * lc.y() + c * lc.z() + d) <= tol_;
+        return std::abs(a * lc.x() + b * lc.y() + c * lc.z() - d) <= tol_;
       }
       double a, b, c, d, tol_;
     };
+
+		/**
+		 * @brief A 3D Spherical shock function |(x-A)^2+(y-B)^2+(z-C)^2-R^2|<=tol.
+     */
+		class SphericalShockFunc : public ShockFunc {
+		public:
+			SphericalShockFunc(double A, double B, double C, double R, double tol) :
+			a(A), b(B), c(C), r(R), tol_(tol) {}
+
+		private:
+			virtual bool eval(apf::Mesh* m, apf::MeshEntity* e) {
+				apf::Vector3 lc = apf::getLinearCentroid(m, e);
+				double i = lc.x() - a, j = lc.y() - b, k = lc.z() - c;
+				return std::abs(i * i + j * j + k * k - r * r) <= tol_;
+			}
+			double a, b, c, r, tol_;
+		};
 
 		ShockFunc* ShockFunc::makeFromString(std::string s, double tol) {
 			std::string::size_type col = s.find(':');
@@ -64,6 +81,11 @@ namespace pc {
 					throw std::invalid_argument("invalid ShockFunc arguments");
 				}
 				return new PlanarShockFunc(args[0], args[1], args[2], args[3], tol);
+			} else if (s_type == "sphere") {
+				if (args.size() != 4) {
+					throw std::invalid_argument("invalid ShockFunc arguments");
+				}
+				return new SphericalShockFunc(args[0], args[1], args[2], args[3], tol);
 			} else {
 				throw std::invalid_argument("invalid ShockFunc type");
 			}

--- a/test/ShockFunc.h
+++ b/test/ShockFunc.h
@@ -7,7 +7,6 @@
 
 namespace pc {
   namespace _test {
-
     /**
      * @brief A ShockFunc is a test fixture that returns true if the element is
      * detected as shock and false otherwise.

--- a/test/ShockFunc.h
+++ b/test/ShockFunc.h
@@ -1,0 +1,43 @@
+#ifndef PC_TEST_SHOCKFUNC_H
+#define PC_TEST_SHOCKFUNC_H
+
+#include <apfMesh.h>
+
+namespace pc {
+  namespace _test {
+
+    /**
+     * @brief A ShockFunc is a test fixture that returns true if the element is
+     * detected as shock and false otherwise.
+     * 
+     */
+    class ShockFunc {
+    public:
+      bool operator()(apf::Mesh* m, apf::MeshEntity* e) {
+        return eval(m, e);
+      }
+    
+    private:
+      virtual bool eval(apf::Mesh* m, apf::MeshEntity* e) = 0;
+    };
+
+    /**
+     * @brief A 3D Planar shock function |Ax+By+Cz+D|<=tol.
+     * 
+     */
+    class PlanarShockFunc : public ShockFunc {
+    public:
+      PlanarShockFunc(double A, double B, double C, double D, double tol) : 
+      a(A), b(B), c(C), d(D), tol_(tol) {}
+
+    private:
+      virtual bool eval(apf::Mesh* m, apf::MeshEntity* e) {
+        apf::Vector3 lc = apf::getLinearCentroid(m, e);
+        return std::abs(a * lc.x() + b * lc.y() + c * lc.z() + d) <= tol_;
+      }
+      double a, b, c, d, tol_;
+    };
+  }
+}
+
+#endif // PC_TEST_SHOCK_FUNC

--- a/test/ShockFunc.h
+++ b/test/ShockFunc.h
@@ -1,6 +1,8 @@
 #ifndef PC_TEST_SHOCKFUNC_H
 #define PC_TEST_SHOCKFUNC_H
 
+#include <string>
+
 #include <apfMesh.h>
 
 namespace pc {
@@ -16,6 +18,8 @@ namespace pc {
       bool operator()(apf::Mesh* m, apf::MeshEntity* e) {
         return eval(m, e);
       }
+
+			static ShockFunc* makeFromString(std::string s, double tol);
     
     private:
       virtual bool eval(apf::Mesh* m, apf::MeshEntity* e) = 0;
@@ -37,6 +41,33 @@ namespace pc {
       }
       double a, b, c, d, tol_;
     };
+
+		ShockFunc* ShockFunc::makeFromString(std::string s, double tol) {
+			std::string::size_type col = s.find(':');
+			if (col == std::string::npos) {
+				throw std::invalid_argument("malformed ShockFunc descriptor");
+			}
+
+			std::string s_type = s.substr(0, col);
+
+			++col;
+			std::vector<int> args;
+			while (col < s.size()) {
+				std::string::size_type comma = s.find(',', col);
+				args.push_back(std::stof(s.substr(col, comma - col)));
+				if (comma == std::string::npos) break;
+				col = comma + 1;
+			}
+
+			if (s_type == "plane") {
+				if (args.size() != 4) {
+					throw std::invalid_argument("invalid ShockFunc arguments");
+				}
+				return new PlanarShockFunc(args[0], args[1], args[2], args[3], tol);
+			} else {
+				throw std::invalid_argument("invalid ShockFunc type");
+			}
+		}
   }
 }
 

--- a/test/test_defragmentation.cc
+++ b/test/test_defragmentation.cc
@@ -23,7 +23,7 @@ namespace pc {
 
 void print_usage(std::ostream& str, char* argv0) {
   str << "USAGE: " << argv0 << " <modelFileName> <meshFileName>"
-      << " <A> <B> <C> <D> <tol_alpha> <fragmentation>"
+      << " type:arg,arg,... <tol_alpha> <fragmentation>"
       << std::endl;
 }
 
@@ -102,7 +102,7 @@ int main (int argc, char* argv[]) {
   // lion verbosity
   lion_set_verbosity(1);
 
-  if (argc != 9) {
+  if (argc != 6) {
     print_usage(std::cerr, argv[0]);
     return -1;
   }
@@ -123,15 +123,14 @@ int main (int argc, char* argv[]) {
   int fragmentation;
 
   try {
-    double a = std::atof(argv[3]), b = std::atof(argv[4]);
-    double c = std::atof(argv[5]), d = std::atof(argv[6]);
-    double tol_alpha = std::atof(argv[7]);
+    double tol_alpha = std::atof(argv[4]);
     double tol = calculateTolerance(tol_alpha, m);
-    fragmentation = std::atoi(argv[8]);
+    fragmentation = std::atoi(argv[5]);
 
     std::cout << "Tolerance: " << tol << std::endl;
 
-    sf = new pc::_test::PlanarShockFunc(a, b, c, d, tol);
+    sf = pc::_test::ShockFunc::makeFromString(argv[3], tol);
+		if (sf == nullptr) throw std::invalid_argument("ShockFunc argument");
   } catch (const std::exception& e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
     print_usage(std::cerr, argv[0]);

--- a/test/test_defragmentation.cc
+++ b/test/test_defragmentation.cc
@@ -1,0 +1,148 @@
+#include <cassert>
+#include <random>
+#include <iostream>
+#include <chrono>
+
+#include <apfMesh2.h>
+#include <apfShape.h>
+#include <PCU.h>
+#include <lionPrint.h>
+#include <phstream.h>
+#include <gmi_mesh.h>
+#include <apfMDS.h>
+
+#include <chef.h>
+#include <phInput.h>
+
+#include "pcShockParam.h"
+#include "ShockFunc.h"
+
+namespace pc {
+  // Function we are testing.
+  void defragmentShocksSerial(const ph::Input& in, apf::Mesh2* m);
+}
+
+void print_usage(std::ostream& str, char* argv0) {
+	str << "USAGE: " << argv0
+			<< " <modelFileName> <meshFileName> <A> <B> <C> <D> <tol>"
+			<< std::endl;
+}
+
+int mockShockParam(apf::Mesh* m, pc::_test::ShockFunc* sf) {
+	assert(m);
+	assert(sf);
+
+  std::mt19937 mt(std::random_device{}());
+  std::uniform_int_distribution<int> dist(0, 100);
+
+	apf::Field* Shock_Param =
+			apf::createField(m, "Shock_Param", apf::SCALAR, apf::getConstant(3));
+
+  int n = 0;
+
+	apf::MeshIterator* it = m->begin(3);
+  for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+    if ((*sf)(m, e) && dist(mt) < 30) {
+      apf::setScalar(Shock_Param, e, 0, pc::ShockParam::SHOCK);
+      ++n;
+    } else {
+      apf::setScalar(Shock_Param, e, 0, pc::ShockParam::NONE);
+    }
+  }
+  m->end(it);
+
+  return n;
+}
+
+int main (int argc, char* argv[]) {
+  // MPI/PCU init?
+  MPI_Init(&argc, &argv);
+  PCU_Comm_Init();
+
+  // lion verbosity
+  lion_set_verbosity(1);
+
+  if (argc != 8) {
+    print_usage(std::cerr, argv[0]);
+    return -1;
+  }
+
+  apf::Mesh2* m = nullptr;
+  pc::_test::ShockFunc* sf = nullptr;
+
+  ph::Input in;
+
+  try {
+    in.modelFileName = std::string(argv[1]);
+    in.meshFileName = std::string(argv[2]);
+    double a = std::atof(argv[3]), b = std::atof(argv[4]);
+    double c = std::atof(argv[5]), d = std::atof(argv[6]);
+    double tol = std::atof(argv[7]);
+
+    // FIXME: Replace tol with tolerance based on a fraction of mesh size.
+    sf = new pc::_test::PlanarShockFunc(a, b, c, d, tol);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl;
+    print_usage(std::cerr, argv[0]);
+    return -1;
+  }
+
+  // Init gmi.
+  gmi_register_mesh();
+
+  // Load mesh.
+  m = apf::loadMdsMesh(in.modelFileName.c_str(), in.meshFileName.c_str());
+
+  apf::Vector3 c_min, c_max;
+  apf::MeshIterator* it = m->begin(0);
+  for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+    apf::Vector3 lc = apf::getLinearCentroid(m, e);
+    c_min.x() = c_min.x() < lc.x() ? c_min.x() : lc.x();
+    c_min.y() = c_min.y() < lc.y() ? c_min.y() : lc.y();
+    c_min.z() = c_min.z() < lc.z() ? c_min.z() : lc.z();
+    c_max.x() = c_max.x() > lc.x() ? c_max.x() : lc.x();
+    c_max.y() = c_max.y() > lc.y() ? c_max.y() : lc.y();
+    c_max.z() = c_max.z() > lc.z() ? c_max.z() : lc.z();
+  }
+  m->end(it);
+
+  apf::Vector3 m_size = c_max - c_min;
+
+  // Enable the 1ms literal.
+  using namespace std::literals;
+
+  // Print mesh statistics.
+  std::cout << "Mesh size: (" << m_size.x() << ", " << m_size.y() << ", " << m_size.z() << ")." << std::endl;
+  std::cout << "Mesh elements (D=3): " << m->count(3) << std::endl;
+
+  auto clock_start = std::chrono::system_clock::now();
+  int n = mockShockParam(m, sf);
+  auto clock_end = std::chrono::system_clock::now();
+
+  // Print Shock_Param statistics.
+  // - number of elements.
+  std::cout << "Assigned " << n << " shock elements: " << (clock_end - clock_start) / 1ms << "ms." << std::endl;
+
+  // Write pre-defrag VTK file.
+  apf::writeVtkFiles("defrag_pre.vtk", m);
+
+  // Defrag step
+  clock_start = std::chrono::system_clock::now();
+  pc::defragmentShocksSerial(in, m);
+  clock_end = std::chrono::system_clock::now();
+  std::cout << "Defragmentation: " << (clock_end - clock_start) / 1ms << "ms." << std::endl;
+  
+  // Write post-defrag VTK files.
+  apf::writeVtkFiles("defrag_post.vtk", m);
+
+  // Write Simmetrix file.
+
+  // Cleanup
+  m->destroyNative();
+  apf::destroyMesh(m);
+
+  PCU_Comm_Free();
+  MPI_Finalize();
+
+  return 0;
+}

--- a/test/test_labeling.cc
+++ b/test/test_labeling.cc
@@ -1,0 +1,73 @@
+#include <cassert>
+#include <random>
+#include <iostream>
+#include <chrono>
+
+#include <apfMesh2.h>
+#include <apfShape.h>
+#include <PCU.h>
+#include <lionPrint.h>
+#include <gmi_mesh.h>
+#include <apfMDS.h>
+#include <phInput.h>
+
+namespace pc {
+  using Shocks = std::vector<std::vector<apf::MeshEntity*>>;
+
+  // Function we are testing:
+  Shocks labelShocksSerial(const ph::Input& in, apf::Mesh2* m);
+}
+
+void print_usage(std::ostream& str, char* argv0) {
+  str << "USAGE: " << argv0 << " <modelFileName> <meshFileName>" << std::endl;
+}
+
+int main (int argc, char* argv[]) {
+  MPI_Init(&argc, &argv);
+  PCU_Comm_Init();
+
+  lion_set_verbosity(1);
+
+  if (argc != 3) {
+    print_usage(std::cerr, argv[0]);
+    return -1;
+  }
+
+  apf::Mesh2* m = nullptr;
+
+  ph::Input in;
+  in.modelFileName = std::string(argv[1]);
+  in.meshFileName = std::string(argv[2]);
+
+  // Init gmi.
+  gmi_register_mesh();
+
+  // Load mesh.
+  m = apf::loadMdsMesh(in.modelFileName.c_str(), in.meshFileName.c_str());
+
+  // Enable the 1ms literal.
+  using namespace std::literals;
+
+  auto clock_start = std::chrono::system_clock::now();
+  pc::Shocks shocks = pc::labelShocksSerial(in, m);
+  auto clock_end = std::chrono::system_clock::now();
+
+	std::cout << "Labeled " << shocks.size() << " distinct shocks." << std::endl;
+
+  std::cout << "Labeling: " << (clock_end - clock_start) / 1ms << "ms." << std::endl;
+
+  // Write post-label VTK files.
+  apf::writeVtkFiles("td_label.vtk", m);
+
+  // Write MDS mesh.
+  m->writeNative("labeled.smb");
+
+  // Cleanup.
+  m->destroyNative();
+  apf::destroyMesh(m);
+
+  PCU_Comm_Free();
+  MPI_Finalize();
+
+  return 0;
+}

--- a/test/test_prisms.cc
+++ b/test/test_prisms.cc
@@ -22,8 +22,8 @@ apf::Mesh2* createMesh(void) {
   gmi_model* g = gmi_load(".null");
   apf::Mesh2* m = apf::makeEmptyMdsMesh(g, 3, false);
 
-  const int prisms = 4 * 2, tets = prisms * 3 + 2, planeverts = 6,
-    verts = planeverts * 3 + 2;
+  const int prisms = 4 * 2, tets = prisms * 3 + 5, planeverts = 6,
+    verts = planeverts * 3 + 5;
 
   double coordsZ0[planeverts * 2] = {
     0, 0, 1, 0, 0, 1, 1, 1, 2, 0, 2, 1
@@ -41,12 +41,21 @@ apf::Mesh2* createMesh(void) {
     coords[(i + planeverts * 2) * 3 + 2] = -1;
   }
 
-  coords[54] = 3;
+  coords[54] = 3; // vert 18, tet 24.
   coords[55] = 1;
   coords[56] = 1;
-  coords[57] = -1;
+  coords[57] = -1; // vert 19, tet 25.
   coords[58] = 0;
   coords[59] = -1;
+  coords[60] = 0; // vert 20, tet 26.
+  coords[61] = 2;
+  coords[62] = 1.5;
+  coords[63] = 0; // vert 21, tet 27.
+  coords[64] = -1;
+  coords[65] = 2;
+  coords[66] = 2; // vert 22, tet 28.
+  coords[67] = 2;
+  coords[68] = 2;
 
   apf::Gid conn[tets * 4] = {
     0,6,7,8,/**/ 0,1,8,7,/**/ 0,1,2,8, // Prism 1
@@ -57,7 +66,8 @@ apf::Mesh2* createMesh(void) {
     13,15,2,3,/**/ 13,15,14,2,/**/ 13,2,1,3, // Prism 6
     13,1,4,3,/**/ 13,16,3,4,/**/ 13,16,15,3, // Prism 7
     16,17,3,5,/**/ 16,17,15,3,/**/ 16,3,4,5, // Prism 8
-    4,16,5,18, /*Start tet*/ 0,8,2,19 /*End tet*/
+    4,16,5,18, /*Tet 24*/ 0,8,2,19, /*Tet 25*/ 2,3,15,20, /*Tet 26*/
+    1,10,7,21, /*Tet 27*/ 3,8,9,22 /*Tet 28*/
   };
 
   apf::GlobalToVert outmap;
@@ -83,6 +93,7 @@ apf::Mesh2* createMesh(void) {
 std::vector<apf::MeshEntity*> tetsById;
 
 void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, const std::vector<int>& steps) {
+  std::cout << "Testing ray " << fieldname << '.' << std::endl;
   apf::Field* ray = apf::createField(m, fieldname, apf::SCALAR, apf::getConstant(3));
   apf::zeroField(ray);
   int step = 0;
@@ -91,7 +102,7 @@ void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, cons
     if (step < steps.size()) {
       if (e != tetsById[steps[step]]) {
         fprintf(stderr, "ERROR: Expected to be at element %p but actually at"
-          "element %p.\n", tetsById[steps[step]], e);
+          " element %p.\n", tetsById[steps[step]], e);
         exit(EXIT_FAILURE);
       }
     } else {
@@ -106,6 +117,21 @@ void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, cons
   }
 }
 
+void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id) {
+  std::cout << "Testing ray " << fieldname << '.' << std::endl;
+  apf::Field* ray = apf::createField(m, fieldname, apf::SCALAR, apf::getConstant(3));
+  apf::zeroField(ray);
+  int step = 0;
+  pc::rayTrace(m, tetsById[start_id], tetsById[end_id], [ray, &step](apf::Mesh* m, apf::MeshEntity* e) {
+    apf::setScalar(ray, e, 0, step + 1);
+    if (step > tetsById.size()) {
+      fprintf(stderr, "Error: too many steps. Infinite loop?\n");
+      exit(EXIT_FAILURE);
+    }
+    ++step;
+  });
+}
+
 void testRays(apf::Mesh2* m) {
   apf::Numbering* tet_id = m->findNumbering("tet id");
 
@@ -114,13 +140,18 @@ void testRays(apf::Mesh2* m) {
   for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
     int id = apf::getNumber(tet_id, e, 0, 0);
     tetsById[id] = e;
-    std::cout << "Tet " << id << ": " << e << std::endl;
+    std::cout << "Tet " << id << ": " << e << ": " <<
+      apf::getLinearCentroid(m, e) << std::endl;
   }
   m->end(it);
 
   testRay(m, "ray1", 10, 8, {10, 8});
   testRay(m, "ray2", 10, 0, {10, 8, 3, 5, 1, 0});
   testRay(m, "ray3", 24, 25, {24, 10, 18, 4, 12, 25});
+  testRay(m, "ray4", 15, 24);
+  testRay(m, "ray5", 26, 17, {26, 17});
+  testRay(m, "ray6", 26, 13, {26, 15, 17, 13});
+  testRay(m, "ray7", 27, 28);
 }
 
 int main (int argc, char* argv[]) {

--- a/test/test_prisms.cc
+++ b/test/test_prisms.cc
@@ -101,19 +101,20 @@ void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, cons
     apf::setScalar(ray, e, 0, step + 1);
     if (step < steps.size()) {
       if (e != tetsById[steps[step]]) {
-        fprintf(stderr, "ERROR: Expected to be at element %p but actually at"
-          " element %p.\n", tetsById[steps[step]], e);
+        std::cerr << "ERROR: Expected to be at element "
+                  << tetsById[steps[step]] << " but actually at element "
+                  << e << std::endl;
         exit(EXIT_FAILURE);
       }
     } else {
-      fprintf(stderr, "Error: too many steps. Infinite loop?\n");
+      std::cerr << "ERROR: Too many steps. Infinite loop?" << std::endl;
       exit(EXIT_FAILURE);
     }
     ++step;
   });
   if (step != steps.size()) {
     std::cerr << "ERROR: Ray " << fieldname << " stopped at step " << step << std::endl;
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 }
 
@@ -125,7 +126,7 @@ void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id) {
   pc::rayTrace(m, tetsById[start_id], tetsById[end_id], [ray, &step](apf::Mesh* m, apf::MeshEntity* e) {
     apf::setScalar(ray, e, 0, step + 1);
     if (step > tetsById.size()) {
-      fprintf(stderr, "Error: too many steps. Infinite loop?\n");
+      std::cerr << "ERROR: too many steps. Infinite loop?" << std::endl;
       exit(EXIT_FAILURE);
     }
     ++step;
@@ -147,11 +148,17 @@ void testRays(apf::Mesh2* m) {
 
   testRay(m, "ray1", 10, 8, {10, 8});
   testRay(m, "ray2", 10, 0, {10, 8, 3, 5, 1, 0});
-  testRay(m, "ray3", 24, 25, {24, 10, 18, 4, 12, 25});
-  testRay(m, "ray4", 15, 24);
+
+  // Ray passes through faces so it may not be deterministic.
+  testRay(m, "ray3", 24, 25/*, {24, 10, 18, 4, 12, 25}*/);
+
+  testRay(m, "ray4", 15, 24, {15, 20, 19, 23, 24});
   testRay(m, "ray5", 26, 17, {26, 17});
   testRay(m, "ray6", 26, 13, {26, 15, 17, 13});
-  testRay(m, "ray7", 27, 28);
+
+  // Real choices are 5 or 6. 5 has a slightly further centroid, so it seems
+  // more "aligned".
+  testRay(m, "ray7", 27, 28, {27, 5, 28});
 }
 
 int main (int argc, char* argv[]) {

--- a/test/test_prisms.cc
+++ b/test/test_prisms.cc
@@ -1,0 +1,123 @@
+#include <iostream>
+#include <PCU.h>
+#include <lionPrint.h>
+#include <gmi_null.h>
+#include <gmi_mesh.h>
+#include <apfMDS.h>
+#include <apf.h>
+#include <apfMesh2.h>
+#include <apfConvert.h>
+#include <apfNumbering.h>
+#include <apfShape.h>
+#include <pcu_util.h>
+
+namespace pc {
+  // Private test target.
+  void rayTrace(apf::Mesh* m, apf::MeshEntity* start, apf::MeshEntity* end, std::function<void(apf::Mesh* m, apf::MeshEntity* e)>);
+}
+
+apf::Mesh2* createMesh(void) {
+  gmi_register_null();
+  gmi_register_mesh();
+  gmi_model* g = gmi_load(".null");
+  apf::Mesh2* m = apf::makeEmptyMdsMesh(g, 3, false);
+
+  const int prisms = 4 * 2, tets = prisms * 3, planeverts = 6,
+    verts = planeverts * 3;
+
+  double coordsZ0[planeverts * 2] = {
+    0, 0, 1, 0, 0, 1, 1, 1, 2, 0, 2, 1
+  };
+  double coords[verts * 3];
+  for (int i = 0; i < planeverts; ++i) {
+    coords[i * 3] = coordsZ0[i * 2]; // x component
+    coords[i * 3 + 1] = coordsZ0[i * 2 + 1]; // y component
+    coords[i * 3 + 2] = 0;
+    coords[(i + planeverts) * 3] = coordsZ0[i * 2]; // x component
+    coords[(i + planeverts) * 3 + 1] = coordsZ0[i * 2 + 1]; // y component
+    coords[(i + planeverts) * 3 + 2] = 1;
+    coords[(i + planeverts * 2) * 3] = coordsZ0[i * 2]; // x component
+    coords[(i + planeverts * 2) * 3 + 1] = coordsZ0[i * 2 + 1]; // y component
+    coords[(i + planeverts * 2) * 3 + 2] = -1;
+  }
+  apf::Gid conn[tets * 4] = {
+    0,6,7,8,/**/ 0,1,8,7,/**/ 0,1,2,8, // Prism 1
+    1,3,8,9,/**/ 1,3,2,8,/**/ 1,8,7,9, // Prism 2
+    1,7,10,9,/**/ 1,4,9,10,/**/ 1,4,3,9, // Prism 3
+    4,5,9,11,/**/ 4,5,3,9,/**/ 4,9,10,11, // Prism 4
+    12,0,1,2,/**/ 12,13,2,1,/**/ 12,13,14,2, // Prism 5
+    13,15,2,3,/**/ 13,15,14,2,/**/ 13,2,1,3, // Prism 6
+    13,1,4,3,/**/ 13,16,3,4,/**/ 13,16,15,3, // Prism 7
+    16,17,3,5,/**/ 16,17,15,3,/**/ 16,3,4,5 // Prism 8
+  };
+
+  apf::GlobalToVert outmap;
+  apf::NewElements elms = apf::assemble(m, conn, tets, apf::Mesh::TET, outmap);
+  apf::deriveMdsModel(m);
+  apf::finalise(m, outmap);
+  apf::setCoords(m, coords, verts, outmap);
+  m->verify();
+
+  apf::numberOwnedDimension(m, "tet id", 3);
+
+  apf::MeshIterator* it = m->begin(0);
+  for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+    apf::Vector3 pt;
+    m->getPoint(e, 0, pt);
+    std::cout << "Vert " << e << ": " << pt << std::endl;
+  }
+  m->end(it);
+
+  return m;
+}
+
+std::vector<apf::MeshEntity*> tetsById;
+
+void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, const std::vector<int>& steps) {
+  apf::Field* ray = apf::createField(m, fieldname, apf::SCALAR, apf::getConstant(3));
+  apf::zeroField(ray);
+  int step = 0;
+  pc::rayTrace(m, tetsById[start_id], tetsById[end_id], [ray, &step, &steps](apf::Mesh* m, apf::MeshEntity* e) {
+    apf::setScalar(ray, e, 0, step + 1);
+    if (step < steps.size()) {
+      PCU_ALWAYS_ASSERT(e == tetsById[steps[step]]);
+    } else {
+      fprintf(stderr, "Error: too many steps. Infinite loop?\n");
+      exit(EXIT_FAILURE);
+    }
+    ++step;
+  });
+  if (step != steps.size()) {
+    std::cerr << "ERROR: Ray " << fieldname << " stopped at step " << step << std::endl;
+    exit(1);
+  }
+}
+
+void testRays(apf::Mesh2* m) {
+  apf::Numbering* tet_id = m->findNumbering("tet id");
+
+  tetsById.resize(m->count(3));
+  apf::MeshIterator* it = m->begin(3);
+  for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+    int id = apf::getNumber(tet_id, e, 0, 0);
+    tetsById[id] = e;
+  }
+  m->end(it);
+
+  testRay(m, "ray1", 10, 8, {10, 8});
+  testRay(m, "ray2", 10, 0, {10, 8, 3, 5, 1, 0});
+}
+
+int main (int argc, char* argv[]) {
+  MPI_Init(&argc, &argv);
+  PCU_Comm_Init();
+  lion_set_verbosity(1);
+  apf::Mesh2* m = createMesh();
+  apf::writeVtkFiles("test_prisms_pre.vtk", m, 3);
+  testRays(m);
+  apf::writeVtkFiles("test_prisms_post.vtk", m, 3);
+  m->destroyNative();
+  apf::destroyMesh(m);
+  PCU_Comm_Free();
+  MPI_Finalize();
+}

--- a/test/test_raytracing.cc
+++ b/test/test_raytracing.cc
@@ -55,7 +55,7 @@ apf::Mesh2* createMesh(void) {
 
 namespace pc {
   int getFaceVertsCCW(apf::Mesh* m, apf::MeshEntity* e, int face, apf::MeshEntity** verts);
-  int edgeIndicator(apf::Mesh* m, const apf::Vector3& src, const apf::Vector3& dst,
+  int edgeIndicator(apf::Mesh* m, const apf::Vector3& src, const apf::Vector3& ray,
                 apf::MeshEntity* v1, apf::MeshEntity* v2);
 }
 
@@ -66,12 +66,12 @@ void testReorder(apf::Mesh* m) {
     apf::Downward faces;
     int face_ct = m->getDownward(tet, 2, faces);
     for (int i = 0; i < face_ct; ++i) {
-      apf::Vector3 face_lc = apf::getLinearCentroid(m, faces[i]);
+      apf::Vector3 face_ray = apf::getLinearCentroid(m, faces[i]) - lc;
       apf::Downward verts;
       int vert_ct = pc::getFaceVertsCCW(m, tet, i, verts); //m->getDownward(faces[i], 0, verts);
       verts[vert_ct] = verts[0];
       for (int j = 0; j < vert_ct; ++j) {
-        int ind = pc::edgeIndicator(m, lc, face_lc, verts[j], verts[j + 1]);
+        int ind = pc::edgeIndicator(m, lc, face_ray, verts[j], verts[j + 1]);
         if (ind != 1) {
           fprintf(stderr, "ERROR: Tet %p face %d (%p,%p,%p) "
                   "does not point outward!\n", tet, i, verts[0], verts[1], verts[2]);

--- a/test/test_raytracing.cc
+++ b/test/test_raytracing.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <PCU.h>
 #include <lionPrint.h>
 #include <gmi_null.h>
@@ -11,7 +12,7 @@
 
 namespace pc {
   // Private test target.
-  void rayTrace(apf::Mesh2* m, apf::MeshEntity* start, apf::MeshEntity* end, std::function<void(apf::Mesh2* m, apf::MeshEntity* e)>);
+  void rayTrace(apf::Mesh* m, apf::MeshEntity* start, apf::MeshEntity* end, std::function<void(apf::Mesh* m, apf::MeshEntity* e)>);
 }
 
 apf::Mesh2* createMesh(void) {
@@ -41,46 +42,85 @@ apf::Mesh2* createMesh(void) {
 
   apf::numberOwnedDimension(m, "tet id", 3);
 
+  apf::MeshIterator* it = m->begin(0);
+  for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+    apf::Vector3 pt;
+    m->getPoint(e, 0, pt);
+    std::cout << "Vert " << e << ": " << pt << std::endl;
+  }
+  m->end(it);
+
 	return m;
 }
 
-void testRay(apf::Mesh2* m) {
-	apf::Numbering* tet_id = m->findNumbering("tet id");
+namespace pc {
+  int getFaceVertsCCW(apf::Mesh* m, apf::MeshEntity* e, int face, apf::MeshEntity** verts);
+  int edgeIndicator(apf::Mesh* m, const apf::Vector3& src, const apf::Vector3& dst,
+                apf::MeshEntity* v1, apf::MeshEntity* v2);
+}
 
-	apf::MeshEntity* tet1, *tet2;
-	apf::MeshIterator* it = m->begin(3);
-	for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
-		int id = apf::getNumber(tet_id, e, 0, 0);
-		if (id == 2) tet1 = e;
-		if (id == 5) tet2 = e;
-	}
-	m->end(it);
-	
-	apf::Field* ray = apf::createField(m, "ray", apf::SCALAR, apf::getConstant(3));
+void testReorder(apf::Mesh* m) {
+  apf::MeshIterator* it = m->begin(3);
+  for (apf::MeshEntity* tet = m->iterate(it); tet; tet = m->iterate(it)) {
+    apf::Vector3 lc = apf::getLinearCentroid(m, tet);
+    apf::Downward faces;
+    int face_ct = m->getDownward(tet, 2, faces);
+    for (int i = 0; i < face_ct; ++i) {
+      apf::Vector3 face_lc = apf::getLinearCentroid(m, faces[i]);
+      apf::Downward verts;
+      int vert_ct = pc::getFaceVertsCCW(m, tet, i, verts); //m->getDownward(faces[i], 0, verts);
+      verts[vert_ct] = verts[0];
+      for (int j = 0; j < vert_ct; ++j) {
+        int ind = pc::edgeIndicator(m, lc, face_lc, verts[j], verts[j + 1]);
+        if (ind != 1) {
+          fprintf(stderr, "ERROR: Tet %p face %d (%p,%p,%p) "
+                  "does not point outward!\n", tet, i, verts[0], verts[1], verts[2]);
+          exit(EXIT_FAILURE);
+        }
+      }
+    }
+  }
+  m->end(it);
+}
+
+std::vector<apf::MeshEntity*> tetsById;
+
+void testRay(apf::Mesh* m, const char* fieldname, int start_id, int end_id, const std::vector<int>& steps) {
+	apf::Field* ray = apf::createField(m, fieldname, apf::SCALAR, apf::getConstant(3));
   apf::zeroField(ray);
-
   int step = 1;
-  pc::rayTrace(m, tet1, tet2, [tet_id, ray, &step](apf::Mesh2* m, apf::MeshEntity* e) {
+  pc::rayTrace(m, tetsById[start_id], tetsById[end_id], [ray, &step, &steps](apf::Mesh* m, apf::MeshEntity* e) {
     apf::setScalar(ray, e, 0, step);
-    switch (step) {
-    case 1:
-      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 2);
-      break;
-    case 2:
-      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 0);
-      break;
-    case 3:
-      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 1);
-      break;
-    case 4:
-      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 5);
-      break;
-    default:
+    if (step <= steps.size()) {
+      PCU_ALWAYS_ASSERT(e == tetsById[steps[step - 1]]);
+    } else {
       fprintf(stderr, "Error: too many steps. Infinite loop?\n");
       exit(EXIT_FAILURE);
     }
     ++step;
   });
+}
+
+void testRays(apf::Mesh2* m) {
+	apf::Numbering* tet_id = m->findNumbering("tet id");
+
+	tetsById.resize(m->count(3));
+	apf::MeshIterator* it = m->begin(3);
+	for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+		int id = apf::getNumber(tet_id, e, 0, 0);
+    tetsById[id] = e;
+	}
+	m->end(it);
+
+  testRay(m, "ray1", 2, 5, {2, 0, 1, 5});
+  testRay(m, "ray2", 2, 0, {2, 0});
+  testRay(m, "ray3", 0, 1, {0, 1});
+  testRay(m, "ray4", 1, 3, {1, 3});
+  testRay(m, "ray5", 1, 4, {1, 4});
+  testRay(m, "ray6", 1, 0, {1, 0});
+  testRay(m, "ray7", 3, 1, {3, 1});
+  testRay(m, "ray8", 4, 1, {4, 1});
+  testRay(m, "ray9", 0, 1, {0, 1});
 }
 
 int main (int argc, char* argv[]) {
@@ -89,12 +129,14 @@ int main (int argc, char* argv[]) {
 	lion_set_verbosity(1);
 	apf::Mesh2* m = createMesh();
 
-	testRay(m);
+  apf::writeVtkFiles("test_raytracing_pre.vtk", m, 3);
 
-	apf::writeVtkFiles("tets.vtk", m, 3);
-	apf::writeVtkFiles("tris.vtk", m, 2);
-	gmi_write_dmg(m->getModel(), "tets.dmg");
-	m->writeNative("tets.smb");
+  testReorder(m);
+	testRays(m);
+
+	apf::writeVtkFiles("test_raytracing_tets.vtk", m, 3);
+	gmi_write_dmg(m->getModel(), "test_raytracing_tets.dmg");
+	m->writeNative("test_raytracing_tets.smb");
 
 	m->destroyNative();
 	apf::destroyMesh(m);

--- a/test/test_raytracing.cc
+++ b/test/test_raytracing.cc
@@ -1,0 +1,103 @@
+#include <PCU.h>
+#include <lionPrint.h>
+#include <gmi_null.h>
+#include <apfMDS.h>
+#include <apf.h>
+#include <apfMesh2.h>
+#include <apfConvert.h>
+#include <apfNumbering.h>
+#include <apfShape.h>
+#include <pcu_util.h>
+
+namespace pc {
+  // Private test target.
+  void rayTrace(apf::Mesh2* m, apf::MeshEntity* start, apf::MeshEntity* end, std::function<void(apf::Mesh2* m, apf::MeshEntity* e)>);
+}
+
+apf::Mesh2* createMesh(void) {
+	gmi_register_null();
+	gmi_model* g = gmi_load(".null");
+	apf::Mesh2* m = apf::makeEmptyMdsMesh(g, 3, false);
+
+  const int tets = 6, verts = 8;
+
+	apf::Gid conn[tets * 4] = {0, 2, 3, 1, /**/ 0, 2, 4, 3, /**/ 1, 5, 2, 3,
+  4, 2, 0, 6, /**/ 4, 0, 3, 7, /**/ 4, 0, 7, 6};
+	double coords[verts * 3] = {0, 1, 1,
+		0, -1, 1,
+		-1, 0, 0,
+		1, 0, 0,
+		0, 1, 0,
+		0, -1, 0,
+    -1, 1.5, 0.5,
+    1, 1.5, 0.5};
+
+	apf::GlobalToVert outmap;
+	apf::NewElements elms = apf::assemble(m, conn, tets, apf::Mesh::TET, outmap);
+	apf::deriveMdsModel(m);
+	apf::setCoords(m, coords, verts, outmap);
+	apf::finalise(m, outmap);
+	m->verify();
+
+  apf::numberOwnedDimension(m, "tet id", 3);
+
+	return m;
+}
+
+void testRay(apf::Mesh2* m) {
+	apf::Numbering* tet_id = m->findNumbering("tet id");
+
+	apf::MeshEntity* tet1, *tet2;
+	apf::MeshIterator* it = m->begin(3);
+	for (apf::MeshEntity* e = m->iterate(it); e; e = m->iterate(it)) {
+		int id = apf::getNumber(tet_id, e, 0, 0);
+		if (id == 2) tet1 = e;
+		if (id == 5) tet2 = e;
+	}
+	m->end(it);
+	
+	apf::Field* ray = apf::createField(m, "ray", apf::SCALAR, apf::getConstant(3));
+  apf::zeroField(ray);
+
+  int step = 1;
+  pc::rayTrace(m, tet1, tet2, [tet_id, ray, &step](apf::Mesh2* m, apf::MeshEntity* e) {
+    apf::setScalar(ray, e, 0, step);
+    switch (step) {
+    case 1:
+      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 2);
+      break;
+    case 2:
+      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 0);
+      break;
+    case 3:
+      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 1);
+      break;
+    case 4:
+      PCU_ALWAYS_ASSERT(apf::getNumber(tet_id, e, 0, 0) == 5);
+      break;
+    default:
+      fprintf(stderr, "Error: too many steps. Infinite loop?\n");
+      exit(EXIT_FAILURE);
+    }
+    ++step;
+  });
+}
+
+int main (int argc, char* argv[]) {
+	MPI_Init(&argc, &argv);
+	PCU_Comm_Init();
+	lion_set_verbosity(1);
+	apf::Mesh2* m = createMesh();
+
+	testRay(m);
+
+	apf::writeVtkFiles("tets.vtk", m, 3);
+	apf::writeVtkFiles("tris.vtk", m, 2);
+	gmi_write_dmg(m->getModel(), "tets.dmg");
+	m->writeNative("tets.smb");
+
+	m->destroyNative();
+	apf::destroyMesh(m);
+	PCU_Comm_Free();
+	MPI_Finalize();
+}

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -100,5 +100,17 @@ add_test(NAME test_raytracing
   --build-makeprogram ${CMAKE_MAKE_PROGRAM}
   --build-target test_raytracing
   --build-exe-dir "${CMAKE_BINARY_DIR}/test"
+  --build-run-dir "${CMAKE_BINARY_DIR}/test"
   --build-noclean
   --test-command test_raytracing)
+
+add_test(NAME test_prisms
+  COMMAND "${CMAKE_CTEST_COMMAND}"
+  --build-and-test "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}"
+  --build-generator ${CMAKE_GENERATOR}
+  --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+  --build-target test_prisms
+  --build-exe-dir "${CMAKE_BINARY_DIR}/test"
+  --build-run-dir "${CMAKE_BINARY_DIR}/test"
+  --build-noclean
+  --test-command test_prisms)

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -100,4 +100,5 @@ add_test(NAME test_raytracing
   --build-makeprogram ${CMAKE_MAKE_PROGRAM}
   --build-target test_raytracing
   --build-exe-dir "${CMAKE_BINARY_DIR}/test"
+  --build-noclean
   --test-command test_raytracing)

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -92,3 +92,12 @@ if( ${phastaIC_FOUND} )
       )
   endif()
 endif()
+
+add_test(NAME test_raytracing
+  COMMAND "${CMAKE_CTEST_COMMAND}"
+  --build-and-test "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}"
+  --build-generator ${CMAKE_GENERATOR}
+  --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+  --build-target test_raytracing
+  --build-exe-dir "${CMAKE_BINARY_DIR}/test"
+  --test-command test_raytracing)


### PR DESCRIPTION
Add tests for defragmentation, raytracing, and labeling.
Replace fuzzy defragmentation with ray-tracing between disparate shock elements.
Fix uninitalized `apf::Vector3`s.
Fix mach number calculation.
Add status messages.
Fix memory leak by deleting `apf::Sharing*` in `pc::locateShockEdges`.
Fix `pc::filterShockParam` not getting values.
Write more intermediate Vtk files.
Add explicit bridgeDim to `pc::serialBFS`.
Add R. Chorda et al. edge indicator.
Add function to get face verts in CCW order around the outward face normal.
- [x] Add other element types.

Add ray tracing.
Add defragmentation using ray tracing.
Replace empty bfs distance with -1 so that Paraview magnitude looks normal.
Clear `pc_cs_bfs` in `pc::denoiseShocksSerial`.
Add test shock functions (plane, sphere, cylinders).
Add raytracing test with prisms.

- [x] #3 